### PR TITLE
[docs] Update the readme version for the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please see the below examples on how to use this plugin with buildkite. The [bui
 steps:
   - label: ":partyparrot: Creating the pipeline"
     plugins:
-      - Zegocover/git-diff-conditional#v0.1.0:
+      - Zegocover/git-diff-conditional#v0.1.1:
           dynamic_pipeline: ".buildkite/dynamic_pipeline.yml"
           steps:
             - label: "build and deploy lambda"


### PR DESCRIPTION
to: @wizardels 
cc: @zegocover/git-diff-conditional-buildkite-plugin-maintainers
related to:
resolves:

## Background

When updating the release, the readme requires updating too

## Changes

* Updating the version the readme points too

## Testing

Ran `docker-compose up --build` locally and observed exit codes of `0` across the board