### PR TITLE
Fix detection of block vs label

### DIFF
--- a/scripts/generate_pipeline.py
+++ b/scripts/generate_pipeline.py
@@ -134,7 +134,7 @@ class GitDiffConditional:
 
     @staticmethod
     def check_if_skip(conditional_steps: dict, step: dict) -> bool:
-        label = step["label"]
+        label = step["label"] if "label" in step else step["block"]
 
         if "skip" in step:
             # Skip setings already exist

--- a/tests/unit/test_git_diff_conditional.py
+++ b/tests/unit/test_git_diff_conditional.py
@@ -202,6 +202,11 @@ def test_load_conditions_from_environment(
             {"test_3": True},
             [{"label": "test_3", "skip": True}, {"label": "test_3_a", "skip": False}],
         ),  # skip true/false
+        (
+            [{"label": "test_4_label"}, {"block": "test_4_block"}],
+            {"test_4_label": True, "test_4_block": True},
+            [{"label": "test_4_label", "skip": True}, {"block": "test_4_block", "skip": True}],
+        )
     ],
 )
 def test_generate_pipeline_from_conditions(

--- a/tests/unit/test_git_diff_conditional.py
+++ b/tests/unit/test_git_diff_conditional.py
@@ -205,8 +205,11 @@ def test_load_conditions_from_environment(
         (
             [{"label": "test_4_label"}, {"block": "test_4_block"}],
             {"test_4_label": True, "test_4_block": True},
-            [{"label": "test_4_label", "skip": True}, {"block": "test_4_block", "skip": True}],
-        )
+            [
+                {"label": "test_4_label", "skip": True},
+                {"block": "test_4_block", "skip": True},
+            ],
+        ),  # Check label and block
     ],
 )
 def test_generate_pipeline_from_conditions(


### PR DESCRIPTION
to: @wizardels 
cc: @zegocover/git-diff-conditional-buildkite-plugin-maintainers
related to:
resolves: #8 

## Background

When i ran a pipeline which contained a `block` as a step, the pipeline failed

## Changes

* steps containing a  `block` are now supported
* added a test to check that `block` is read correctly

## Testing

Added a test to check that a pipeline containing `block` is read correctly