### PR TITLE
[core] Add git_mirror support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,17 @@ The above example `initial_pipeline` will skip the `build and deploy lambda` ste
 
 ## Configuration
 
-| Option           | Required |   Type    | Default | Description                                                                                                                                     |
-| ---------------- | :------: | :-------: | :-----: | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| dynamic_pipeline |   Yes    | `string`  |         | The name including the path to the pipeline that contains all the actual `steps`                                                                |
-| disable_plugin   |    No    | `boolean` | `false` | This can be used to pass the entire `dynamic_pipeline` pipeline straight to buildkite without skipping a single step.                           |
-| diff             |    No    | `string`  |         | Can be used to override the default commands (see below for a better explanation of the defaults)                                               |
-| log_level        |    No    | `string`  | `INFO`  | The Level of logging to be used by the python script underneath. Pass `DEBUG` for verbose logging if errors occur                               |
-| steps            |   Yes    |  `array`  |         | Each Step should contain a `label` with the `include`/`exclude` settings relevant to the label it applies to within the `dynamic_pipeline` file |
-| label            |   Yes    | `string`  |         | The `label` these conditions apply to within the `dynamic_pipeline` file. (These should be an EXACT match)                                      |
-| include          |    No    |  `array`  |         | If any element is found within the `git diff` then this step will NOT be skipped                                                                |
-| exclude          |    No    |  `array`  |         | If any alement is found within the `git diff` then this step will be SKIPPED                                                                    |
+| Option           | Required |   Type    | Default | Description                                                                                                                                                                   |
+| ---------------- | :------: | :-------: | :-----: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| dynamic_pipeline |   Yes    | `string`  |         | The name including the path to the pipeline that contains all the actual `steps`                                                                                              |
+| git_mirrors_path |    No    | `string`  |         | The Path that the agent uses for `git-mirror-path`, This will be mounted into the container. See [git mirrors](https://github.com/buildkite/agent/blob/master/EXPERIMENTS.md) |
+| disable_plugin   |    No    | `boolean` | `false` | This can be used to pass the entire `dynamic_pipeline` pipeline straight to buildkite without skipping a single step.                                                         |
+| diff             |    No    | `string`  |         | Can be used to override the default commands (see below for a better explanation of the defaults)                                                                             |
+| log_level        |    No    | `string`  | `INFO`  | The Level of logging to be used by the python script underneath. Pass `DEBUG` for verbose logging if errors occur                                                             |
+| steps            |   Yes    |  `array`  |         | Each Step should contain a `label` with the `include`/`exclude` settings relevant to the label it applies to within the `dynamic_pipeline` file                               |
+| label            |   Yes    | `string`  |         | The `label` these conditions apply to within the `dynamic_pipeline` file. (These should be an EXACT match)                                                                    |
+| include          |    No    |  `array`  |         | If any element is found within the `git diff` then this step will NOT be skipped                                                                                              |
+| exclude          |    No    |  `array`  |         | If any alement is found within the `git diff` then this step will be SKIPPED                                                                                                  |
 
 Other useful things to note:
 - Both `include` and `exclude` make use of Unix shell-style wildcards (Look at `.gitignore` files for inspiration)

--- a/hooks/command
+++ b/hooks/command
@@ -5,4 +5,12 @@ basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 
 docker build $basedir -t buildkite-pyyaml > /dev/null
 
-docker run --rm -v "$PWD:/buildkite" --env-file <(env | grep BUILDKITE) buildkite-pyyaml
+set +u
+MIRROS_PATH=${BUILDKITE_PLUGIN_GIT_DIFF_CONDITIONAL_GIT_MIRRORS_PATH}
+set -u
+
+if [[ -z "${MIRROS_PATH}" ]]; then
+  docker run --rm -v "$PWD:/buildkite" --env-file <(env | grep BUILDKITE) buildkite-pyyaml
+else
+  docker run --rm -v "$PWD:/buildkite" -v "${MIRROS_PATH}":"${MIRROS_PATH}" --env-file <(env | grep BUILDKITE) buildkite-pyyaml
+fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,6 +5,8 @@ requirements:
   - docker
 configuration:
   properties:
+    git_mirrors_path:
+      type: string
     dynamic_pipeline:
       type: string
     disable_plugin:


### PR DESCRIPTION
to: @wizardels 
cc: @zegocover/git-diff-conditional-buildkite-plugin-maintainers
related to:
resolves: #7 

## Background

As we are using `git-mirrors` on our buildkite agents, i wanted to add the support for this to the plugin

## Changes

* Added a new flag `git_mirrors_path` which will be mounted into the container if it is set
* Added this flag with a description to the documentation

## Testing

Ran `docker-compose up --build`