### PR TITLE
[docs] Bumping the version in the README ready for the release of v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please see the below examples on how to use this plugin with buildkite. The [bui
 steps:
   - label: ":partyparrot: Creating the pipeline"
     plugins:
-      - Zegocover/git-diff-conditional#v0.1.1:
+      - Zegocover/git-diff-conditional#v0.2.0:
           dynamic_pipeline: ".buildkite/dynamic_pipeline.yml"
           steps:
             - label: "build and deploy lambda"


### PR DESCRIPTION
to: @wizardels 
cc: @zegocover/git-diff-conditional-buildkite-plugin-maintainers
related to:
resolves:

## Background

Version bump for release `v0.2.0`

## Changes

* Version bump for release

## Testing

CI