### PR TITLE
Bug/wait steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please see the below examples on how to use this plugin with buildkite. The [bui
 steps:
   - label: ":partyparrot: Creating the pipeline"
     plugins:
-      - Zegocover/git-diff-conditional#v1.1.0:
+      - Zegocover/git-diff-conditional#v1.1.1:
           dynamic_pipeline: ".buildkite/dynamic_pipeline.yml"
           steps:
             - label: "build and deploy lambda"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,6 @@ pytest==5.4.1
 pytest-mock==2.0.0
 pytest-randomly==3.2.1
 pytest-cov==2.8.1
+pytest-sugar
 black
 isort

--- a/scripts/generate_pipeline.py
+++ b/scripts/generate_pipeline.py
@@ -121,7 +121,7 @@ class GitDiffConditional:
         pipeline = {"steps": []}
 
         for step in dynamic_pipeline["steps"]:
-            if isinstance(step, dict):
+            if isinstance(step, dict) and "wait" not in step.keys():
                 # Only check for actual steps, not waits
                 step["skip"] = self.check_if_skip(conditions, step)
 

--- a/tests/unit/test_git_diff_conditional.py
+++ b/tests/unit/test_git_diff_conditional.py
@@ -206,13 +206,24 @@ def test_load_conditions_from_environment(
             [{"label": "test_3", "skip": True}, {"label": "test_3_a", "skip": False}],
         ),  # skip true/false
         (
-            [{"label": "test_4_label"}, {"block": "test_4_block"}],
+            [{"label": "test_4_label"}, "wait", {"block": "test_4_block"}],
             {"test_4_label": True, "test_4_block": True},
             [
                 {"label": "test_4_label", "skip": True},
+                "wait",
                 {"block": "test_4_block", "skip": True},
             ],
         ),  # Check label and block
+        (
+            ["wait"],
+            {},
+            ["wait"],
+        ),  # basic wait step
+        (
+            [{"wait": None, "continue_on_failure": True}],
+            {},
+            [{"wait": None, "continue_on_failure": True}],
+        ),  # dictionary wait step
     ],
 )
 def test_generate_pipeline_from_conditions(


### PR DESCRIPTION
to:
cc: @zegocover/git-diff-conditional-buildkite-plugin-maintainers
related to:
resolves: #17 

## Background

when using a pipeline which had a more complex `wait` step the plugin failed. This should resolve that

## Changes

* if a step is a `dict` but has `wait` in its keys then it will not run the block within the `if` statement
* Add `pytest-sugar` for better test output (ticks vs dots)
![Screenshot 2020-09-16 at 15 50 40](https://user-images.githubusercontent.com/39212456/93353937-6386fc00-f834-11ea-8db8-d05cc9e2b7fb.png)


## Testing

ran `black` `isort` and `pytest` locally