### PR TITLE
Only look for env vars that *start* with BUILDKITE

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -45,7 +45,7 @@ fi
 
 docker build "$basedir" -t buildkite-pyyaml > /dev/null
 
-docker run --rm -v "$PWD:/buildkite" --env-file <(env | grep BUILDKITE) buildkite-pyyaml
+docker run --rm -v "$PWD:/buildkite" --env-file <(env -0 | grep -z '\^BUILDKITE' | tr '\0' '\n') buildkite-pyyaml
 
 if [[ -s ".git_diff_conditional/pipeline_output" ]]; then
   echo "Uploading the pipeline to the buildkite-agent"


### PR DESCRIPTION
to:
cc: @zegocover/git-diff-conditional-buildkite-plugin-maintainers
related to:
resolves: #21 


Rather than filtering env vars to pass to buildkite-pyyaml by those that
*contain* the string BUILDKITE, filter to variables that *start* with
BUILDKITE, using the -0 flag to env and the -z flag to grep to delimit
the variables by null characters rather than newlines so we don't also
grab lines inside multi-line env vars (such as the commit message)
