### PR TITLE
[core] use python:3.7-slim-bullseye docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7-slim-bullseye
 
 RUN apt-get update && \
     apt-get upgrade -y

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7-slim-bullseye
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/tests/unit/test_git_diff_conditional.py
+++ b/tests/unit/test_git_diff_conditional.py
@@ -170,7 +170,6 @@ def test_load_conditions_from_environment(
     diff,
     expected_result,
 ):
-
     for key, value in pipeline_as_env.items():
         monkeypatch.setenv(f"{PLUGIN_PREFIX}_STEPS_{key}", value)
 

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -12,7 +12,6 @@ def get_diff_mock(mocker):
 
 # Tests
 def setup_git_diff_conditional_mock(mocker, condition_return_value):
-
     return_value = mocker.MagicMock(
         spec=GitDiffConditional,
         load_dynamic_pipeline=mocker.Mock(return_value={}),


### PR DESCRIPTION
to: @jack1902
cc: @zegocover/git-diff-conditional-buildkite-plugin-maintainers
resolves: https://github.com/Zegocover/git-diff-conditional-buildkite-plugin/issues/23

## Background
This plugin is failing for us since the latest version of the `python:3.7-slim` image was pushed. 

## Changes
Updates the Dockerfile to use the `python:3.7-slim-bullseye` image instead. Other commenters on the python issue [have reported](https://github.com/docker-library/python/issues/836#issuecomment-1592563371) that this is enough to get things running again.

## Testing

I'm not familiar with the project, and haven't touched python code in a long time. What's the best way to verify this is working?